### PR TITLE
Remove Hack Club’s Segment config

### DIFF
--- a/site/gatsby-config.js
+++ b/site/gatsby-config.js
@@ -13,13 +13,6 @@ module.exports = {
       options: {
         siteUrl: 'https://summer.hackclub.com'
       }
-    },
-    {
-      resolve: 'gatsby-plugin-segment-js',
-      options: {
-        prodKey: '35oTlU4UqlhIN8VGYmBxAzyDdfzhcscw',
-        trackPage: true
-      }
     }
   ]
 }


### PR DESCRIPTION
Removing our hackclub.com Segment configuration from this site so the analytics don’t mix :+1: